### PR TITLE
debug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 #CC = ${CC} # C compiler
+DEBUG = y
 CFLAGS = -fPIC -Wall -Wextra -O2 -g # C flags
 CFLAGS += -D__USRLIB__ # Only use this makefile for compiling user-space library
 CFLAGS += -std=gnu99 -Wno-declaration-after-statement -fgnu89-inline
-ifeq ($(DEBUG), 1)
+ifeq ($(DEBUG), y)
 	CFLAGS += -D__DEBUG__
 else
 endif

--- a/ccp.c
+++ b/ccp.c
@@ -211,14 +211,6 @@ int ccp_read_msg(
     struct InstallExpressionMsg emsg;
     struct UpdateFieldsMsg fields_msg;
 
-#ifdef __DEBUG__
-    PRINT("\n%s: got: [", __FUNCTION__);
-    for (i = 0; i < bufsize; i++) {
-        PRINT("%d, ", buf[i]);
-    }
-    PRINT("]\n");
-#endif
-
     ok = read_header(&hdr, buf);  
     if (ok < 0) {
         PRINT("read header failed: %d", ok);

--- a/ccp.h
+++ b/ccp.h
@@ -23,7 +23,11 @@
     #define __MALLOC__(size) malloc(size)
     #define __FREE__(ptr) free(ptr)
 #else
-    #define DBG_PRINT(fmt, args...)
+    #ifdef __DEBUG__
+        #define DBG_PRINT(fmt, args...) printk(KERN_INFO "libccp: " fmt, ## args)
+    #else
+        #define DBG_PRINT(fmt, args...)
+    #endif
     #define PRINT(fmt, args...) printk(KERN_INFO "libccp: " fmt, ## args)
     #define __INLINE__ inline
     #define __MALLOC__(size) kmalloc(size, GFP_KERNEL)
@@ -35,6 +39,7 @@
     #include <stdbool.h>
 #else
     #include <linux/types.h>
+    #include <linux/module.h>
 #endif
 
 typedef uint8_t u8;


### PR DESCRIPTION
If `debug=y` in the makefile (can also be set in the outer ccp-kernel makefile), the state machine will print out all of the instructions its executing for debugging purposes. here's an example from syslog:
```
May 19 20:02:29 pd5 kernel: [978160.691541] libccp: >>> program starting <<<
May 19 20:02:29 pd5 kernel: [978160.691543] libccp: when #0 {
May 19 20:02:29 pd5 kernel: [978160.691544] libccp: BIND
May 19 20:02:29 pd5 kernel: [978160.691545] libccp: } => 1
May 19 20:02:29 pd5 kernel: [978160.691546] libccp: ADD  0 + 0 = 0
May 19 20:02:29 pd5 kernel: [978160.691547] libccp: BIND
May 19 20:02:29 pd5 kernel: [978160.691548] libccp: MIN  21183 , 31050 => 21183
May 19 20:02:29 pd5 kernel: [978160.691548] libccp: BIND
May 19 20:02:29 pd5 kernel: [978160.691549] libccp: MIN  713883 , 531144 => 531144
May 19 20:02:29 pd5 kernel: [978160.691550] libccp: MAX  684088 , 531144 => 684088
May 19 20:02:29 pd5 kernel: [978160.691551] libccp: BIND
May 19 20:02:29 pd5 kernel: [978160.691551] libccp: BIND
May 19 20:02:29 pd5 kernel: [978160.691552] libccp: BIND
May 19 20:02:29 pd5 kernel: [978160.691552] libccp: fallthrough...
May 19 20:02:29 pd5 kernel: [978160.691553] libccp: >>> program finished ret=0 <<<
```

It's all inside debug flags, so it doesn't affect runtime performance when `debug=n`.
(further discussion is on zulip)