### PR TITLE
integration_test: Script to run CCP integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,25 @@
-language: c
+language: rust
+rust:
+    - nightly
+cache: cargo
 os:
     - linux
     - osx
+addons:
+    apt:
+        sources:
+            - ubuntu-toolchain-r-test
+        packages:
+            - g++-6
+            - llvm-dev
+            - libclang-dev
+            - clang
+
 matrix:
     # works on Precise and Trusty
     - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-6
       env:
         - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
 script:
     - make
+    - python3 integration_test.py

--- a/integration_test.py
+++ b/integration_test.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python3
+
+import subprocess
+
+curr_commit_cmd = "git rev-parse HEAD^@ | tail -n 1"
+clone_cmd = "git clone --recursive https://github.com/ccp-project/portus"
+checkout_libccp_commit = "cd ./portus/integration_tests/libccp_integration/libccp && git fetch && git checkout {}"
+run_integration_test = "cd ./portus && make libccp-integration"
+clean_cmd = "rm -rf portus"
+
+curr_commit = subprocess.check_output(curr_commit_cmd, shell=True).strip().decode('utf-8')
+print("libccp commit", curr_commit)
+print("===cloning portus===")
+subprocess.check_call(clone_cmd, shell=True)
+print("===checkout libccp commit===")
+subprocess.check_call(checkout_libccp_commit.format(curr_commit), shell=True)
+print("===run integration test===")
+subprocess.check_call(run_integration_test, shell=True)
+print("===clean up===")
+subprocess.check_call(clean_cmd, shell=True)


### PR DESCRIPTION
https://github.com/ccp-project/portus already implements an integration
test for interoperability between portus and libccp. However, proposed
modifications to libccp are not currently tested in CI for compatibility
with existing portus master branch. This script fills the gap by cloning
the portus repository, checking out the current libccp commit in the
libccp submodule within the integration test, and running the
integration test.