### PR TITLE
remove global state

### DIFF
--- a/ccp.c
+++ b/ccp.c
@@ -537,7 +537,7 @@ int ccp_read_msg(
         // as all programs are sent down separately, right now we check if its a new portus starting
         // by checking if the ID of the program is 0
         // TODO: remove this hack
-        if (expr_msg_info.program_uid == 0) {
+        if (expr_msg_info.program_uid == 1) {
             memset(datapath_programs, 0, MAX_NUM_PROGRAMS * sizeof(struct DatapathProgram));
         }
 

--- a/ccp.c
+++ b/ccp.c
@@ -34,6 +34,13 @@ void __INLINE__ null_log(struct ccp_datapath *dp, enum ccp_log_level level, cons
 }
 
 /*
+ * IMPORTANT: caller must allocate..
+ * 1. ccp_datapath
+ * 2. ccp_datapath.ccp_active_connections with enough space for `max_connections` `ccp_connections`
+ * 3. ccp_datapath.state with enough space for `max_programs` `DatapathPrograms`
+ * ccp_init has no way of checking if enough space has been allocated, so any memory oob errors are
+ * likely a result not allocating enough space
+ *
  * All calls to libccp require a ccp_datapath structure. This function should be called before any
  * other libccp functions and ensures (as much as possible) that the datapath structure has been
  * initialized correctly. A valid ccp_datapath must contain:
@@ -76,6 +83,11 @@ int ccp_init(struct ccp_datapath *datapath) {
     return 0;
 }
 
+/*
+ * Helper function free all memory associated with a ccp_datapath struct. 
+ * Since the caller has allocated all of the memory themselves, they can also free it themselves,
+ * this function is just provided for convenience. 
+ */
 void ccp_free(struct ccp_datapath *datapath) {
     __FREE__(datapath->state);
     __FREE__(datapath->ccp_active_connections);

--- a/ccp.h
+++ b/ccp.h
@@ -149,8 +149,7 @@ struct ccp_datapath {
 
     size_t max_programs;
     // list of datapath programs
-    void *state; // TODO why is this void rather than an explicit list of datapath programs since
-                 // we always cast it to that anyway?
+    struct DatapathProgram *programs;
 
     size_t max_connections;
     // list of active connections this datapath is handling

--- a/ccp_priv.c
+++ b/ccp_priv.c
@@ -8,10 +8,9 @@
 #include <string.h>
 #endif
 
-extern struct ccp_datapath *datapath;
-
-int init_ccp_priv_state(struct ccp_connection *conn) {
+int init_ccp_priv_state(struct ccp_datapath *datapath, struct ccp_connection *conn) {
     struct ccp_priv_state *state;
+
     conn->state = __CALLOC__(1, sizeof(struct ccp_priv_state));
     state = (struct ccp_priv_state*) conn->state;
 
@@ -19,6 +18,9 @@ int init_ccp_priv_state(struct ccp_connection *conn) {
     state->implicit_time_zero = datapath->time_zero;
     state->program_index = 0;
     state->staged_program_index = -1;
+
+    conn->datapath = datapath;
+
     return 0;
 }
 

--- a/ccp_priv.h
+++ b/ccp_priv.h
@@ -24,13 +24,11 @@
 
 #ifdef __KERNEL__
     #define __INLINE__       inline
-    #define __MALLOC__(size) kmalloc(size, GFP_KERNEL)
     #define __CALLOC__(num_elements, block_size) kcalloc(num_elements, block_size, GFP_KERNEL)
     #define __FREE__(ptr)    kfree(ptr)
     #define CAS(a,o,n)       cmpxchg(a,o,n) == o
 #else
     #define __INLINE__
-    #define __MALLOC__(size) malloc(size)
     #define __CALLOC__(num_elements, block_size) calloc(num_elements, block_size)
     #define __FREE__(ptr)    free(ptr)
     #define CAS(a,o,n)       __sync_bool_compare_and_swap(a,o,n)

--- a/ccp_priv.h
+++ b/ccp_priv.h
@@ -14,7 +14,11 @@
 #define FMT_U64 "%llu"
 #define FMT_U32 "%lu"
 #else
+#if defined(__APPLE__)
+#define FMT_U64 "%llu"
+#else
 #define FMT_U64 "%lu"
+#endif
 #define FMT_U32 "%u"
 #endif
 

--- a/ccp_priv.h
+++ b/ccp_priv.h
@@ -175,21 +175,21 @@ int update_register(
 /* Reset the output state registers to their default values
  * according to the DEF instruction preamble.
  */
-void reset_state(struct ccp_priv_state *state);
+void reset_state(struct ccp_datapath *datapath, struct ccp_priv_state *state);
 
 /* Initializes the control registers to their default values
  * according to the DEF instruction preamble.
  */
-void init_register_state(struct ccp_priv_state *state);
+void init_register_state(struct ccp_datapath *datapath, struct ccp_priv_state *state);
 
 /* Reset the implicit time registers to count from datapath->now()
  */
-void reset_time(struct ccp_priv_state *state);
+void reset_time(struct ccp_datapath *datapath, struct ccp_priv_state *state);
 
 /* Initialize send machine and measurement machine state in ccp_connection.
  * Called from ccp_connection_start()
  */
-int init_ccp_priv_state(struct ccp_connection *conn);
+int init_ccp_priv_state(struct ccp_datapath *datapath, struct ccp_connection *conn);
 /* Free the allocated flow memory.
  * Call when the flow has ended.
  */

--- a/ccp_priv.h
+++ b/ccp_priv.h
@@ -43,33 +43,33 @@
 }
 
 // __LOG_INFO__ is default
-#define trace(fmt, args...) 
-#define debug(fmt, args...) 
-#define info(fmt, args...) log_fmt(INFO, fmt, ## args)
-#define warn(fmt, args...) log_fmt(WARN, fmt, ## args)
-#define error(fmt, args...) log_fmt(ERROR, fmt, ## args)
+#define libccp_trace(fmt, args...) 
+#define libccp_debug(fmt, args...) 
+#define libccp_info(fmt, args...) log_fmt(INFO, fmt, ## args)
+#define libccp_warn(fmt, args...) log_fmt(WARN, fmt, ## args)
+#define libccp_error(fmt, args...) log_fmt(ERROR, fmt, ## args)
 
 #ifdef __LOG_TRACE__
-#undef trace
-#define trace(fmt, args...) log_fmt(TRACE, fmt, ## args)
-#undef debug
-#define debug(fmt, args...) log_fmt(DEBUG, fmt, ## args)
+#undef libccp_trace
+#define libccp_trace(fmt, args...) log_fmt(libccp_trace, fmt, ## args)
+#undef libccp_debug
+#define libccp_debug(fmt, args...) log_fmt(libccp_debug, fmt, ## args)
 #endif
 
 #ifdef __LOG_DEBUG__
-#undef debug
-#define debug(fmt, args...) log_fmt(DEBUG, fmt, ## args)
+#undef libccp_debug
+#define libccp_debug(fmt, args...) log_fmt(libccp_debug, fmt, ## args)
 #endif
 
 #ifdef __LOG_WARN__
-#undef info
-#define info(fmt, args...) 
+#undef libccp_info
+#define libccp_info(fmt, args...) 
 #endif
 #ifdef __LOG_ERROR__
-#undef info
-#define info(fmt, args...) 
-#undef warn
-#define warn(fmt, args...)
+#undef libccp_info
+#define libccp_info(fmt, args...) 
+#undef libccp_warn
+#define libccp_warn(fmt, args...)
 #endif
 
 #ifdef __CPLUSPLUS__

--- a/machine.c
+++ b/machine.c
@@ -270,26 +270,26 @@ static int process_instruction(struct ccp_datapath *datapath, struct DatapathPro
     arg2 = read_reg(datapath, state, primitives, current_instruction.rRight);
     switch (current_instruction.op) {
         case ADD:
-            trace("ADD  " FMT_U64 " + " FMT_U64 " = " FMT_U64 "\n", arg1, arg2, myadd64(arg1, arg2)); 
+            libccp_trace("ADD  " FMT_U64 " + " FMT_U64 " = " FMT_U64 "\n", arg1, arg2, myadd64(arg1, arg2)); 
             result = myadd64(arg1, arg2);
             if (result < arg1) {
-                warn("ERROR! Integer overflow: " FMT_U64 " + " FMT_U64 "\n", arg1, arg2);
+                libccp_warn("ERROR! Integer overflow: " FMT_U64 " + " FMT_U64 "\n", arg1, arg2);
                 return -1;
             }
             write_reg(datapath, state, result, current_instruction.rRet);
             break;
         case DIV:
-            trace("DIV  " FMT_U64 " / " FMT_U64 " = ", arg1, arg2);
+            libccp_trace("DIV  " FMT_U64 " / " FMT_U64 " = ", arg1, arg2);
             if (arg2 == 0) {
-                warn("ERROR! Attempt to divide by 0: " FMT_U64 " / " FMT_U64 "\n", arg1, arg2);
+                libccp_warn("ERROR! Attempt to divide by 0: " FMT_U64 " / " FMT_U64 "\n", arg1, arg2);
                 return -1;
             } else {
-                trace("" FMT_U64 "\n", mydiv64(arg1, arg2));
+                libccp_trace("" FMT_U64 "\n", mydiv64(arg1, arg2));
                 write_reg(datapath, state, mydiv64(arg1, arg2), current_instruction.rRet);
             }
             break;
         case EQUIV:
-            trace("EQV  " FMT_U64 " == " FMT_U64 " => " FMT_U64 "\n", arg1, arg2, myequiv64(arg1, arg2));
+            libccp_trace("EQV  " FMT_U64 " == " FMT_U64 " => " FMT_U64 "\n", arg1, arg2, myequiv64(arg1, arg2));
             write_reg(datapath, state, myequiv64(arg1, arg2), current_instruction.rRet);
             break;
         case EWMA: // arg0 = current, arg2 = new, arg1 = constant
@@ -297,61 +297,61 @@ static int process_instruction(struct ccp_datapath *datapath, struct DatapathPro
             write_reg(datapath, state, myewma64(arg1, arg0, arg2), current_instruction.rRet);
             break;
         case GT:
-            trace("GT   " FMT_U64 " > " FMT_U64 " => " FMT_U64 "\n", arg1, arg2, mygt64(arg1, arg2));
+            libccp_trace("GT   " FMT_U64 " > " FMT_U64 " => " FMT_U64 "\n", arg1, arg2, mygt64(arg1, arg2));
             write_reg(datapath, state, mygt64(arg1, arg2), current_instruction.rRet);
             break;
         case LT:
-            trace("LT   " FMT_U64 " > " FMT_U64 " => " FMT_U64 "\n", arg1, arg2, mylt64(arg1, arg2));
+            libccp_trace("LT   " FMT_U64 " > " FMT_U64 " => " FMT_U64 "\n", arg1, arg2, mylt64(arg1, arg2));
             write_reg(datapath, state, mylt64(arg1, arg2), current_instruction.rRet);
             break;
         case MAX:
-            trace("MAX  " FMT_U64 " , " FMT_U64 " => " FMT_U64 "\n", arg1, arg2, mymax64(arg1, arg2));
+            libccp_trace("MAX  " FMT_U64 " , " FMT_U64 " => " FMT_U64 "\n", arg1, arg2, mymax64(arg1, arg2));
             write_reg(datapath, state, mymax64(arg1, arg2), current_instruction.rRet);
             break;
         case MIN:
-            trace("MIN  " FMT_U64 " , " FMT_U64 " => " FMT_U64 "\n", arg1, arg2, mymin64(arg1, arg2));
+            libccp_trace("MIN  " FMT_U64 " , " FMT_U64 " => " FMT_U64 "\n", arg1, arg2, mymin64(arg1, arg2));
             write_reg(datapath, state, mymin64(arg1, arg2), current_instruction.rRet);
             break;
         case MUL:
-            trace("MUL  " FMT_U64 " * " FMT_U64 " = " FMT_U64 "\n", arg1, arg2, mymul64(arg1, arg2));
+            libccp_trace("MUL  " FMT_U64 " * " FMT_U64 " = " FMT_U64 "\n", arg1, arg2, mymul64(arg1, arg2));
             result = mymul64(arg1, arg2);
             if (result < arg1 && arg2 > 0) {
-                error("ERROR! Integer overflow: " FMT_U64 " * " FMT_U64 "\n", arg1, arg2);
+                libccp_error("ERROR! Integer overflow: " FMT_U64 " * " FMT_U64 "\n", arg1, arg2);
                 return -1;
             }
             write_reg(datapath, state, result, current_instruction.rRet);
             break;
         case SUB:
-            trace("SUB  " FMT_U64 " - " FMT_U64 " = " FMT_U64 "\n", arg1, arg2, mysub64(arg1, arg2));
+            libccp_trace("SUB  " FMT_U64 " - " FMT_U64 " = " FMT_U64 "\n", arg1, arg2, mysub64(arg1, arg2));
             result = mysub64(arg1, arg2);
             if (result > arg1) {
-                error("ERROR! Integer underflow: " FMT_U64 " - " FMT_U64 "\n", arg1, arg2);
+                libccp_error("ERROR! Integer underflow: " FMT_U64 " - " FMT_U64 "\n", arg1, arg2);
                 return -1;
             }
             write_reg(datapath, state, result, current_instruction.rRet);
             break;
         case MAXWRAP:
-            trace("MAXW " FMT_U64 " , " FMT_U64 " => " FMT_U64 "\n", arg1, arg2, mymax64_wrap(arg1, arg2));
+            libccp_trace("MAXW " FMT_U64 " , " FMT_U64 " => " FMT_U64 "\n", arg1, arg2, mymax64_wrap(arg1, arg2));
             write_reg(datapath, state, mymax64_wrap(arg1, arg2), current_instruction.rRet);
             break;
         case IF: // if arg1 (rLeft), stores rRight in rRet
-            trace("IF   " FMT_U64 " : r" FMT_U64 " -> r" FMT_U64 "\n", arg1, arg2, current_instruction.rRet.value);
+            libccp_trace("IF   " FMT_U64 " : r" FMT_U64 " -> r" FMT_U64 "\n", arg1, arg2, current_instruction.rRet.value);
             if (arg1) {
                 write_reg(datapath, state, arg2, current_instruction.rRet);
             }
             break;
         case NOTIF:
-            trace("!IF  " FMT_U64 " : r" FMT_U64 " -> r" FMT_U64 "\n", arg1, arg2, current_instruction.rRet.value);
+            libccp_trace("!IF  " FMT_U64 " : r" FMT_U64 " -> r" FMT_U64 "\n", arg1, arg2, current_instruction.rRet.value);
             if (arg1 == 0) {
                 write_reg(datapath, state, arg2, current_instruction.rRet);
             }
             break;
         case BIND: // take arg2, and put it in rRet
-            trace("BIND r" FMT_U64 " -> r" FMT_U64 "\n", arg2, current_instruction.rRet.value);
+            libccp_trace("BIND r" FMT_U64 " -> r" FMT_U64 "\n", arg2, current_instruction.rRet.value);
             write_reg(datapath, state, arg2, current_instruction.rRet);
             break;
         default:
-            debug("UNKNOWN OP %d\n", current_instruction.op);
+            libccp_debug("UNKNOWN OP %d\n", current_instruction.op);
             break;
     }
     return 0;
@@ -366,14 +366,14 @@ static int process_expression(struct ccp_datapath *datapath, struct DatapathProg
     struct Expression *expression = &(program->expressions[expr_index]);
     u8 idx;
     int ret;
-    trace("when #%d {\n", expr_index);
+    libccp_trace("when #%d {\n", expr_index);
     for (idx=expression->cond_start_idx; idx<(expression->cond_start_idx + expression->num_cond_instrs); idx++) {
        ret = process_instruction(datapath, program, idx, state, primitives);
        if (ret < 0) {
          return -1;
        }
     }
-    trace("} => " FMT_U64 "\n", state->registers.impl_registers[EXPR_FLAG_REG]);
+    libccp_trace("} => " FMT_U64 "\n", state->registers.impl_registers[EXPR_FLAG_REG]);
 
     // flag from event is promised to be stored in this implicit register
     if (state->registers.impl_registers[EXPR_FLAG_REG] ) {
@@ -479,7 +479,7 @@ void reset_state(struct ccp_datapath *datapath, struct ccp_priv_state *state) {
     u8 i;
     struct DatapathProgram* program = datapath_program_lookup(datapath, state->program_index);
     if (program == NULL) {
-        info("Cannot reset state because program is NULL\n");
+        libccp_info("Cannot reset state because program is NULL\n");
 	return;
     }
     struct Instruction64 current_instruction;
@@ -526,7 +526,7 @@ void init_register_state(struct ccp_datapath *datapath, struct ccp_priv_state *s
     struct Instruction64 current_instruction;
     struct DatapathProgram* program = datapath_program_lookup(datapath, state->program_index);
     if (program == NULL) {
-        info("Cannot init register state because program is NULL\n");
+        libccp_info("Cannot init register state because program is NULL\n");
 	return;
     }
 
@@ -578,12 +578,12 @@ int state_machine(struct ccp_connection *conn) {
     struct ccp_priv_state *state = get_ccp_priv_state(conn);
     struct ccp_datapath *datapath = conn->datapath;
     if (state == NULL) {
-        warn("CCP priv state is null");
+        libccp_warn("CCP priv state is null");
         return -1;
     }
     struct DatapathProgram* program = datapath_program_lookup(conn->datapath, state->program_index);
     if (program == NULL) {
-        warn("Datapath program is null");
+        libccp_warn("Datapath program is null");
         return -1;
     }
     struct ccp_primitives* primitives = &conn->prims;
@@ -598,12 +598,12 @@ int state_machine(struct ccp_connection *conn) {
     implicit_now = datapath->since_usecs(state->implicit_time_zero);
     state->registers.impl_registers[US_ELAPSED_REG] = implicit_now;
     
-    trace(">>> program starting [sid=%d] <<<\n", conn->index);
+    libccp_trace(">>> program starting [sid=%d] <<<\n", conn->index);
     // cycle through expressions, and process instructions
     for (i=0; i < program->num_expressions; i++) {
         ret = process_expression(datapath, program, i, state, primitives);
         if (ret < 0) {
-            trace(">>> program finished [sid=%d] [ret=-1] <<<\n\n", conn->index);
+            libccp_trace(">>> program finished [sid=%d] [ret=-1] <<<\n\n", conn->index);
             return -1;
         }
 
@@ -611,16 +611,16 @@ int state_machine(struct ccp_connection *conn) {
         if ((state->registers.impl_registers[EXPR_FLAG_REG]) && !(state->registers.impl_registers[SHOULD_FALLTHROUGH_REG])) {
             break;
         }
-        trace("[sid=%d] fallthrough...\n", conn->index);
+        libccp_trace("[sid=%d] fallthrough...\n", conn->index);
     }
     // set rate and cwnd from implicit registers
     if (state->registers.impl_registers[CWND_REG] > 0) {
-        debug("[sid=%d] setting cwnd after program: " FMT_U64 "\n", conn->index, state->registers.impl_registers[CWND_REG]);
+        libccp_debug("[sid=%d] setting cwnd after program: " FMT_U64 "\n", conn->index, state->registers.impl_registers[CWND_REG]);
         datapath->set_cwnd(conn, state->registers.impl_registers[CWND_REG]);
     }
 
     if (state->registers.impl_registers[RATE_REG] != 0) {
-        debug("[sid=%d] setting rate after program: " FMT_U64 "\n", conn->index, state->registers.impl_registers[CWND_REG]);
+        libccp_debug("[sid=%d] setting rate after program: " FMT_U64 "\n", conn->index, state->registers.impl_registers[CWND_REG]);
         datapath->set_rate_abs(conn, state->registers.impl_registers[RATE_REG]);
     }
 
@@ -630,6 +630,6 @@ int state_machine(struct ccp_connection *conn) {
         reset_state(conn->datapath, state);
     }
 
-    trace(">>> program finished [sid=%d] [ret=0] <<<\n\n", conn->index);
+    libccp_trace(">>> program finished [sid=%d] [ret=0] <<<\n\n", conn->index);
     return 0;
 }

--- a/serialize.c
+++ b/serialize.c
@@ -145,12 +145,12 @@ int read_install_expr_msg_hdr(
     } 
 
     if (expr_msg_info->num_expressions > MAX_EXPRESSIONS) {
-        warn("Program to install has too many expressions: %u\n", expr_msg_info->num_expressions);
+        libccp_warn("Program to install has too many expressions: %u\n", expr_msg_info->num_expressions);
         return -2;
     }
 
     if (expr_msg_info->num_instructions > MAX_INSTRUCTIONS) {
-        warn("Program to install has too many instructions: %u\n", expr_msg_info->num_instructions);
+        libccp_warn("Program to install has too many instructions: %u\n", expr_msg_info->num_instructions);
         return -2;
     }
     memcpy(expr_msg_info, buf, sizeof(struct InstallExpressionMsgHdr));
@@ -170,7 +170,7 @@ int check_update_fields_msg(
 
     *num_updates = (u32)*buf;
     if (*num_updates > MAX_MUTABLE_REG) {
-        warn("Too many updates!: %u\n", *num_updates);
+        libccp_warn("Too many updates!: %u\n", *num_updates);
         return -2;
     }
     return sizeof(u32);
@@ -188,7 +188,7 @@ int read_change_prog_msg(
 
     memcpy(change_prog, buf, sizeof(struct ChangeProgMsg));
     if (change_prog->num_updates > MAX_MUTABLE_REG) {
-        warn("Too many updates sent with change prog: %u\n", change_prog->num_updates);
+        libccp_warn("Too many updates sent with change prog: %u\n", change_prog->num_updates);
         return -2;
     }
     return sizeof(struct ChangeProgMsg);

--- a/serialize.c
+++ b/serialize.c
@@ -13,9 +13,6 @@
 #include <string.h>
 #endif
 
-// datapath implementation
-extern struct ccp_datapath* datapath;
-
 /* (type, len, socket_id) header
  * -----------------------------------
  * | Msg Type | Len (2B) | Uint32    |
@@ -138,6 +135,7 @@ int write_measure_msg(
 }
 
 int read_install_expr_msg_hdr(
+    struct ccp_datapath *datapath,
     struct CcpMsgHeader *hdr,
     struct InstallExpressionMsgHdr *expr_msg_info,
     char *buf
@@ -161,6 +159,7 @@ int read_install_expr_msg_hdr(
 }
 
 int check_update_fields_msg(
+    struct ccp_datapath *datapath,
     struct CcpMsgHeader *hdr,
     u32 *num_updates,
     char *buf
@@ -178,6 +177,7 @@ int check_update_fields_msg(
 }
 
 int read_change_prog_msg(
+    struct ccp_datapath *datapath,
     struct CcpMsgHeader *hdr,
     struct ChangeProgMsg *change_prog,
     char *buf

--- a/serialize.h
+++ b/serialize.h
@@ -6,16 +6,8 @@
 #ifndef CCP_SERIALIZE_H
 #define CCP_SERIALIZE_H
 
-#ifdef __KERNEL__
-#include <linux/types.h>
-#else
-#include <stdint.h>
-#endif
-
-typedef uint8_t u8;
-typedef uint16_t u16;
-typedef uint32_t u32;
-typedef uint64_t u64;
+#include "types.h"
+#include "ccp.h"
 
 #ifdef __CPLUSPLUS__
 extern "C" {
@@ -161,6 +153,7 @@ struct __attribute__((packed, aligned(4))) InstallExpressionMsgHdr {
  * }
  */
 int read_install_expr_msg_hdr(
+    struct ccp_datapath *datapath,
     struct CcpMsgHeader *hdr,
     struct InstallExpressionMsgHdr *expr_msg_info,
     char *buf
@@ -182,6 +175,7 @@ struct __attribute__((packed, aligned(1))) UpdateField {
  * }
  */
 int check_update_fields_msg(
+    struct ccp_datapath *datapath,
     struct CcpMsgHeader *hdr,
     u32 *num_updates,
     char *buf
@@ -193,6 +187,7 @@ struct __attribute__((packed, aligned(1))) ChangeProgMsg {
 };
 
 int read_change_prog_msg(
+    struct ccp_datapath *datapath,
     struct CcpMsgHeader *hdr,
     struct ChangeProgMsg *change_prog,
     char *buf

--- a/test.c
+++ b/test.c
@@ -641,8 +641,8 @@ struct ccp_datapath *create_datapath() {
         return NULL;
     }
     datapath->max_programs = MAX_PROGRAMS;
-    datapath->state = __MALLOC__(MAX_PROGRAMS, sizeof(struct DatapathProgram));
-    if (!datapath->state) {
+    datapath->programs = __MALLOC__(MAX_PROGRAMS, sizeof(struct DatapathProgram));
+    if (!datapath->programs) {
         printf("error: failed to allocate memory for datapath programs\n");
         return NULL;
     }

--- a/types.h
+++ b/types.h
@@ -1,0 +1,15 @@
+#ifndef CCP_TYPES_H
+#define CCP_TYPES_H
+
+#ifdef __KERNEL__
+#include <linux/types.h>
+#else
+#include <stdint.h>
+#endif
+
+typedef uint8_t u8;
+typedef uint16_t u16;
+typedef uint32_t u32;
+typedef uint64_t u64;
+
+#endif


### PR DESCRIPTION
(details below also included in commit message)

Prior to this commit, libccp stored all internal state in two global
data structures: a struct `ccp_datapath`, and an array of struct
`ccp_connection`s.

However, newer userspace datapaths, such as mvfst and mtcp, internally
use multiple threads, each tied to a core, and each handling their own
separate set of connections. Using libccp with global state would
require (unnecessary) synchronization, because technically they are not
touching any of the same state.

This commit slightly changes the API to remove all global state:

1. `ccp_init` still allocates space for the struct ccp_datapath, but
instead of storing the pointer internally in a global variable, it
returns it to the caller. The caller is now responsible for storing this
pointer somewhere and including it in all future calls to libccp
functions.
2. The `ccp_active_connections` array is now stored within the
`ccp_datapath` structure in order to tie them together
3. The `ccp_connection` structure now maintains a pointer to its parent
datapath. This prevents having to always pass around the pair of
ccp_connetion and ccp_datapath since they are almost always both needed
when dealing with a connection.