### PR TITLE
implement ready msg

### DIFF
--- a/ccp.c
+++ b/ccp.c
@@ -76,6 +76,7 @@ int ccp_init(struct ccp_datapath *datapath) {
     }
 
     datapath->time_zero = datapath->now();
+
     return 0;
 }
 

--- a/serialize.c
+++ b/serialize.c
@@ -47,11 +47,11 @@ int serialize_header(char *buf, int bufsize, struct CcpMsgHeader *hdr) {
     case READY:
         break;
     default:
-        return -1;
+        return -9;
     }
 
     if (bufsize < ((int)sizeof(struct CcpMsgHeader))) {
-        return -2;
+        return -10;
     }
 
     memcpy(buf, hdr, sizeof(struct CcpMsgHeader));

--- a/serialize.c
+++ b/serialize.c
@@ -44,6 +44,7 @@ int serialize_header(char *buf, int bufsize, struct CcpMsgHeader *hdr) {
     switch (hdr->Type) {
     case CREATE:
     case MEASURE:
+    case READY:
         break;
     default:
         return -1;
@@ -55,6 +56,39 @@ int serialize_header(char *buf, int bufsize, struct CcpMsgHeader *hdr) {
 
     memcpy(buf, hdr, sizeof(struct CcpMsgHeader));
     return sizeof(struct CcpMsgHeader);
+}
+
+int write_ready_msg(
+    char *buf,
+    int bufsize,
+    u32 id
+) {
+    struct CcpMsgHeader hdr;
+    int ok;
+    u16 msg_len = sizeof(struct CcpMsgHeader) + sizeof(u32);
+
+    hdr = (struct CcpMsgHeader) {
+        .Type = READY,
+        .Len = msg_len,
+        .SocketId = 0
+    };
+
+    if (bufsize < 0) {
+        return -1;
+    }
+
+    if (((u32) bufsize) < hdr.Len) {
+        return -2;
+    }
+
+    ok = serialize_header(buf, bufsize, &hdr);
+    if (ok < 0) {
+        return ok;
+    }
+
+    buf += ok;
+    memcpy(buf, &id, sizeof(u32));
+    return hdr.Len;
 }
 
 int write_create_msg(

--- a/serialize.h
+++ b/serialize.h
@@ -41,6 +41,7 @@ int serialize_header(char *buf, int bufsize, struct CcpMsgHeader *hdr);
 #define  INSTALL_EXPR  2
 #define  UPDATE_FIELDS 3
 #define  CHANGE_PROG   4
+#define  READY         5
 
 // Some messages contain strings.
 #define  BIGGEST_MSG_SIZE  32678
@@ -49,6 +50,8 @@ int serialize_header(char *buf, int bufsize, struct CcpMsgHeader *hdr);
 #define CREATE_MSG_SIZE     512
 // size of report msg is approx MAX_REPORT_REG * 8 + 4 + 4
 #define REPORT_MSG_SIZE     900
+
+#define READY_MSG_SIZE      12
 
 // Some messages contain serialized fold instructions.
 #define MAX_EXPRESSIONS    256 // arbitrary TODO: make configurable
@@ -59,6 +62,16 @@ int serialize_header(char *buf, int bufsize, struct CcpMsgHeader *hdr);
 #define MAX_TMP_REG        8
 #define MAX_LOCAL_REG      8
 #define MAX_MUTABLE_REG    222 // # report + # control + cwnd, rate registers
+
+struct __attribute__((packed, aligned(4))) ReadyMsg {
+    u32 id;
+};
+
+int write_ready_msg(
+    char *buf,
+    int bufsize,
+    u32 id
+);
 
 /* CREATE
  * str: the datapath's requested congestion control algorithm (could be overridden)


### PR DESCRIPTION
For new protocol in portus where ccp waits for datapaths to register (with ready) and then sends them datapath programs in ersponse. 