### PR TITLE
Send ready message in ccp_init

### DIFF
--- a/ccp.c
+++ b/ccp.c
@@ -1,5 +1,3 @@
-#include "ccp.h"
-#include "serialize.h"
 #include "ccp_priv.h"
 #include "ccp_error.h"
 

--- a/ccp.c
+++ b/ccp.c
@@ -268,7 +268,7 @@ void ccp_connection_free(struct ccp_datapath *datapath, u16 sid) {
     free_ccp_priv_state(conn);
 
     msg_size = write_measure_msg(msg, REPORT_MSG_SIZE, sid, 0, 0, 0);
-    ret = datapath->send_msg(conn, msg, msg_size);
+    ret = datapath->send_msg(datapath, msg, msg_size);
     if (ret < 0) {
         if (!datapath->_in_fallback)  {
             libccp_warn("error sending close message: %d", ret);
@@ -565,7 +565,7 @@ int send_conn_create(
         return msg_size;
     }
 
-    ret = datapath->send_msg(conn, msg, msg_size);
+    ret = datapath->send_msg(datapath, msg, msg_size);
     if (ret) {
         libccp_debug("error sending create, updating fto_timer")
         _update_fto_timer(datapath);
@@ -625,7 +625,7 @@ int send_measurement(
 
     msg_size = write_measure_msg(msg, REPORT_MSG_SIZE, conn->index, program_uid, fields, num_fields);
     libccp_trace("[sid=%d] In %s\n", conn->index, __FUNCTION__);
-    ret = conn->datapath->send_msg(conn, msg, msg_size);
+    ret = conn->datapath->send_msg(datapath, msg, msg_size);
     if(ret) {
         libccp_debug("error sending measurement, updating fto timer");
         _update_fto_timer(datapath);

--- a/ccp.h
+++ b/ccp.h
@@ -133,7 +133,7 @@ struct ccp_datapath {
     void (*set_rate_abs)(struct ccp_connection *conn, u32 rate);
 
     // IPC communication
-    int (*send_msg)(struct ccp_connection *conn, char *msg, int msg_size);
+    int (*send_msg)(struct ccp_datapath *dp, char *msg, int msg_size);
 
     // logging
     void (*log)(struct ccp_datapath *dp, enum ccp_log_level level, const char* msg, int msg_size);

--- a/serialize.h
+++ b/serialize.h
@@ -46,10 +46,12 @@ int serialize_header(char *buf, int bufsize, struct CcpMsgHeader *hdr);
 // Some messages contain strings.
 #define  BIGGEST_MSG_SIZE  32678
 
-// for create messages, we know they are smaller when we send them up
-#define CREATE_MSG_SIZE     128
+// create messages are fixed length: header + 4 * 6 + 32
+#define CREATE_MSG_SIZE     96
 // size of report msg is approx MAX_REPORT_REG * 8 + 4 + 4
 #define REPORT_MSG_SIZE     900
+// ready message is just a u32.
+#define READY_MSG_SIZE 12
 
 // Some messages contain serialized fold instructions.
 #define MAX_EXPRESSIONS    256 // arbitrary TODO: make configurable
@@ -64,6 +66,15 @@ int serialize_header(char *buf, int bufsize, struct CcpMsgHeader *hdr);
 struct __attribute__((packed, aligned(4))) ReadyMsg {
     u32 id;
 };
+
+/* READY
+ * id: The unique id of this datapath.
+ */
+int write_ready_msg(
+    char *buf,
+    int bufsize,
+    u32 id
+);
 
 /* CREATE
  * congAlg: the datapath's requested congestion control algorithm (could be overridden)

--- a/unittest.c
+++ b/unittest.c
@@ -36,7 +36,7 @@ static void test_ccp_set_rate(struct ccp_connection *conn, u32 rate) {
     c->curr_rate = rate;
 }
 
-static int test_ccp_send_msg(struct ccp_connection *UNUSED(conn), char *msg, int msg_size) {
+static int test_ccp_send_msg(struct ccp_datapath *UNUSED(conn), char *msg, int msg_size) {
     if (expecting_send <= 0) {
         printf("FAIL\nNot expecting send");
         goto fail;
@@ -663,7 +663,16 @@ int main(int UNUSED(argc), char **UNUSED(argv)) {
         goto ret;
     }
 
-    ok = ccp_init(datapath);
+    expecting_send = 12;
+    char ready_msg[12] = {
+        0x05,0x00,
+        0x0c,0x00,
+        0x00,0x00,0x00,0x00,
+        0xaa,0x00,0x00,0x00,
+    };
+    memcpy(&expected_sent_msg, ready_msg, 12);
+
+    ok = ccp_init(datapath, 0xaa);
     if (ok < 0 ) {
         printf("ccp_init error: %d\n", ok);
         goto ret;
@@ -675,7 +684,6 @@ int main(int UNUSED(argc), char **UNUSED(argv)) {
         .curr_cwnd = 0,
         .curr_rate = 0,
     };
-
 
     ok = test_init(datapath, &conn, &my_conn);
     if (ok < 0) {


### PR DESCRIPTION
The `send_msg` callback also now takes a `*ccp_datapath`, which is what it really wanted anyway, rather than a `*ccp_connection`.